### PR TITLE
Added chromatic aberration correction to the frag shader.

### DIFF
--- a/src/ofxOculusRift.cpp
+++ b/src/ofxOculusRift.cpp
@@ -28,29 +28,44 @@ uniform vec2 ScreenCenter;
 uniform vec2 Scale;
 uniform vec2 ScaleIn;
 uniform vec4 HmdWarpParam;
+uniform vec4 ChromAbParam;
 uniform sampler2DRect Texture0;
 uniform vec2 dimensions;
 varying vec2 oTexCoord;
 
-vec2 HmdWarp(vec2 in01)
-{
-	vec2  theta = (in01 - LensCenter) * ScaleIn; // Scales to [-1, 1]
-	float rSq = theta.x * theta.x + theta.y * theta.y;
-	vec2  theta1 = theta * (HmdWarpParam.x + HmdWarpParam.y * rSq +
-							HmdWarpParam.z * rSq * rSq + HmdWarpParam.w * rSq * rSq * rSq);
-	return LensCenter + Scale * theta1;
-
-}
-										 
 void main()
 {
-	vec2 tc = HmdWarp(oTexCoord);
-	if (!all(equal(clamp(tc, ScreenCenter-vec2(0.25,0.5), ScreenCenter+vec2(0.25,0.5)), tc)))
-		gl_FragColor = vec4(0);
-	else
-		gl_FragColor = texture2DRect(Texture0, tc * dimensions);
+	vec2  theta = (oTexCoord - LensCenter) * ScaleIn; // Scales to [-1, 1]
+	float rSq = theta.x * theta.x + theta.y * theta.y;
+    vec2  theta1 = theta * (HmdWarpParam.x +
+                            HmdWarpParam.y * rSq +
+							HmdWarpParam.z * rSq * rSq +
+                            HmdWarpParam.w * rSq * rSq * rSq);
+    
+    // Detect whether blue texture coordinates are out of range
+    // since these will scale out the furthest.
+    vec2 thetaBlue = theta1 * (ChromAbParam.z + ChromAbParam.w * rSq);
+    vec2 tcBlue = LensCenter + Scale * thetaBlue;
+    if (!all(equal(clamp(tcBlue, ScreenCenter - vec2(0.25, 0.5), ScreenCenter + vec2(0.25, 0.5)), tcBlue))) {
+        gl_FragColor = vec4(0);
+    }
+    else {
+        // Now do blue texture lookup.
+        float blue = texture2DRect(Texture0, tcBlue * dimensions).b;
+        
+        // Do green lookup (no scaling).
+        vec2 tcGreen = LensCenter + Scale * theta1;
+        float green = texture2DRect(Texture0, tcGreen * dimensions).g;
+        
+        // Do red scale and lookup.
+        vec2 thetaRed = theta1 * (ChromAbParam.x + ChromAbParam.y * rSq);
+        vec2 tcRed = LensCenter + Scale * thetaRed;
+        float red = texture2DRect(Texture0, tcRed * dimensions).r;
+        
+        gl_FragColor = vec4(red, green, blue, 1);
+    }
 }
-										 );
+                                        );
 
 ofMatrix4x4 toOf(const Matrix4f& m){
 	return ofMatrix4x4(m.M[0][0],m.M[1][0],m.M[2][0],m.M[3][0],
@@ -304,6 +319,11 @@ void ofxOculusRift::draw(){
 								  distortionConfig.K[1],
 								  distortionConfig.K[2],
 								  distortionConfig.K[3]);
+    distortionShader.setUniform4f("ChromAbParam",
+                                  distortionConfig.ChromaticAberration[0],
+                                  distortionConfig.ChromaticAberration[1],
+                                  distortionConfig.ChromaticAberration[2],
+                                  distortionConfig.ChromaticAberration[3]);
 	
 	setupShaderUniforms(OVR::Util::Render::StereoEye_Left);
 	leftEyeMesh.draw();
@@ -330,7 +350,7 @@ void ofxOculusRift::setupShaderUniforms(OVR::Util::Render::StereoEye eye){
 		x = .5;
 		xCenter = -distortionConfig.XCenterOffset;
 	}
-	
+    	
     float as = float(renderTarget.getWidth())/float(renderTarget.getHeight())*.5;
     // We are using 1/4 of DistortionCenter offset value here, since it is
     // relative to [-1,1] range that gets mapped to [0, 0.5].

--- a/src/ofxOculusRift.cpp
+++ b/src/ofxOculusRift.cpp
@@ -55,14 +55,14 @@ void main()
         
         // Do green lookup (no scaling).
         vec2 tcGreen = LensCenter + Scale * theta1;
-        float green = texture2DRect(Texture0, tcGreen * dimensions).g;
+        vec4 center = texture2DRect(Texture0, tcGreen * dimensions);
         
         // Do red scale and lookup.
         vec2 thetaRed = theta1 * (ChromAbParam.x + ChromAbParam.y * rSq);
         vec2 tcRed = LensCenter + Scale * thetaRed;
         float red = texture2DRect(Texture0, tcRed * dimensions).r;
         
-        gl_FragColor = vec4(red, green, blue, 1);
+        gl_FragColor = vec4(red, center.g, blue, center.a);
     }
 }
                                         );


### PR DESCRIPTION
I think... it looks crisper to me but then again my eyes aren't the best.

I ported over this code, which I found in the [OVR docs](http://static.oculusvr.com/sdk-downloads/documents/Oculus_SDK_Overview.pdf).

```
Texture2D Texture : register(t0);
SamplerState Linear : register(s0);
float2 LensCenter;
float2 ScreenCenter;
float2 Scale;
float2 ScaleIn;
float4 HmdWarpParam;
float4 ChromAbParam;

float4 main(in float4 oPosition : SV_Position, in float4 oColor : COLOR,
            in float2 oTexCoord : TEXCOORD0) : SV_Target
{
    float2 theta = (oTexCoord - LensCenter) * ScaleIn; // Scales to [-1, 1]
    float  rSq = theta.x * theta.x + theta.y * theta.y;
    float2 theta1 = theta * (HmdWarpParam.x + HmdWarpParam.y * rSq +
        HmdWarpParam.z * rSq * rSq +
        HmdWarpParam.w * rSq * rSq * rSq);

    // Detect whether blue texture coordinates are out of range
    // since these will scaled out the furthest.
    float2 thetaBlue = theta1 * (ChromAbParam.z + ChromAbParam.w * rSq);
    float2 tcBlue = LensCenter + Scale * thetaBlue;
    if (any(clamp(tcBlue, ScreenCenter -float2(0.25,0.5),
            ScreenCenter+float2(0.25, 0.5)) - tcBlue))
        return 0;

    // Now do blue texture lookup.
    float  blue = Texture.Sample(Linear, tcBlue).b;
    // Do green lookup (no scaling).
    float2 tcGreen = LensCenter + Scale * theta1;
    float  green = Texture.Sample(Linear, tcGreen).g;
    // Do red scale and lookup.
    float2 thetaRed = theta1 * (ChromAbParam.x + ChromAbParam.y * rSq);
    float2 tcRed = LensCenter + Scale * thetaRed;
    float  red = Texture.Sample(Linear,o tcRed).r;

    return float4(red, green, blue, 1); 
}
```

One thing I noticed is that it always returns alpha 1. Is this the behaviour we want? Other options would be to get the min/max/avg of the three looked up pixels.
